### PR TITLE
Refactored local_users, changed auditd location, reinstated confines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
+## Release 1.0.8
+* Change audit.rules entries to /etc/audit/rules.d/audit.rules so persistent across reboots
+* Add '-e 2' to audit.rules to make immutable (activate class cis_4_1_18)
+* Refactor and expand local_users fact and classes cis_5_4_1_1 to cis_5_4_1_5
+* Reinstate confining facts to RedHat
+* Re-add typo in auditd rule cis_4_1_4
+
+## Release 1.0.7
+
+* Added multiple enhancements by Dan Wittenberg
+* Move to PDK 12
+
+## Release 1.0.5
+
+* Confined facts to RedHat family
 
 ## Release 1.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Release 1.0.8
+* Refactoring by CanIHaveThisOne
 * Change audit.rules entries to /etc/audit/rules.d/audit.rules so persistent across reboots
 * Add '-e 2' to audit.rules to make immutable (activate class cis_4_1_18)
 * Refactor and expand local_users fact and classes cis_5_4_1_1 to cis_5_4_1_5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Add '-e 2' to audit.rules to make immutable (activate class cis_4_1_18)
 * Refactor and expand local_users fact and classes cis_5_4_1_1 to cis_5_4_1_5
 * Reinstate confining facts to RedHat
-* Re-add typo in auditd rule cis_4_1_4
+* Re-fix typo in auditd rule cis_4_1_4
 
 ## Release 1.0.7
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -131,7 +131,7 @@
 * [`secure_linux_cis::redhat7::cis_4_1_15`](#secure_linux_cisredhat7cis_4_1_15): 4.1.15 Ensure changes to system administration scope (sudoers) is collected (Scored)
 * [`secure_linux_cis::redhat7::cis_4_1_16`](#secure_linux_cisredhat7cis_4_1_16): 4.1.16 Ensure system administrator actions (sudolog) are collected (Scored)
 * [`secure_linux_cis::redhat7::cis_4_1_17`](#secure_linux_cisredhat7cis_4_1_17): 4.1.17 Ensure kernel module loading and unloading is collected (Scored)
-* [`secure_linux_cis::redhat7::cis_4_1_17`](#secure_linux_cisredhat7cis_4_1_17): 4.1.18 Ensure the audit configuration is immutable (Scored)
+* [`secure_linux_cis::redhat7::cis_4_1_18`](#secure_linux_cisredhat7cis_4_1_17): 4.1.18 Ensure the audit configuration is immutable (Scored)
 * [`secure_linux_cis::redhat7::cis_4_1_1_1`](#secure_linux_cisredhat7cis_4_1_1_1): 4.1.1.1 Ensure audit log storage size is configured (Not Scored)
 * [`secure_linux_cis::redhat7::cis_4_1_1_2`](#secure_linux_cisredhat7cis_4_1_1_2): 4.1.1.2 Ensure system is disabled when audit logs are full (Scored)
 * [`secure_linux_cis::redhat7::cis_4_1_1_3`](#secure_linux_cisredhat7cis_4_1_1_3): 4.1.1.3 Ensure audit logs are not automatically deleted (Scored)

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -131,6 +131,7 @@
 * [`secure_linux_cis::redhat7::cis_4_1_15`](#secure_linux_cisredhat7cis_4_1_15): 4.1.15 Ensure changes to system administration scope (sudoers) is collected (Scored)
 * [`secure_linux_cis::redhat7::cis_4_1_16`](#secure_linux_cisredhat7cis_4_1_16): 4.1.16 Ensure system administrator actions (sudolog) are collected (Scored)
 * [`secure_linux_cis::redhat7::cis_4_1_17`](#secure_linux_cisredhat7cis_4_1_17): 4.1.17 Ensure kernel module loading and unloading is collected (Scored)
+* [`secure_linux_cis::redhat7::cis_4_1_17`](#secure_linux_cisredhat7cis_4_1_17): 4.1.18 Ensure the audit configuration is immutable (Scored)
 * [`secure_linux_cis::redhat7::cis_4_1_1_1`](#secure_linux_cisredhat7cis_4_1_1_1): 4.1.1.1 Ensure audit log storage size is configured (Not Scored)
 * [`secure_linux_cis::redhat7::cis_4_1_1_2`](#secure_linux_cisredhat7cis_4_1_1_2): 4.1.1.2 Ensure system is disabled when audit logs are full (Scored)
 * [`secure_linux_cis::redhat7::cis_4_1_1_3`](#secure_linux_cisredhat7cis_4_1_1_3): 4.1.1.3 Ensure audit logs are not automatically deleted (Scored)

--- a/lib/facter/dot_file_writable.rb
+++ b/lib/facter/dot_file_writable.rb
@@ -4,6 +4,7 @@
 # Contains dot files that are either group or world writable
 
 Facter.add('dot_file_writable') do
+  confine osfamily: 'RedHat'
   setcode do
     Facter::Core::Execution.exec('/tmp/cis_scripts/dot_file_wr.sh')
   end

--- a/lib/facter/duplicate_gid.rb
+++ b/lib/facter/duplicate_gid.rb
@@ -4,6 +4,7 @@
 # Ensures no duplicate GIDs exist in /etc/group
 
 Facter.add('duplicate_gid') do
+  confine osfamily: 'RedHat'
   setcode do
     Facter::Core::Execution.exec('/tmp/cis_scripts/dup_gid.sh')
   end

--- a/lib/facter/duplicate_group.rb
+++ b/lib/facter/duplicate_group.rb
@@ -4,6 +4,7 @@
 # Ensures no duplicate group names exist in /etc/group
 
 Facter.add('duplicate_group') do
+  confine osfamily: 'RedHat'
   setcode do
     Facter::Core::Execution.exec('/tmp/cis_scripts/dup_group.sh')
   end

--- a/lib/facter/duplicate_uid.rb
+++ b/lib/facter/duplicate_uid.rb
@@ -4,6 +4,7 @@
 # Ensures there are no duplicate UIDs in /etc/passwd
 
 Facter.add('duplicate_uid') do
+  confine osfamily: 'RedHat'
   setcode do
     Facter::Core::Execution.exec('/tmp/cis_scripts/dup_uid.sh')
   end

--- a/lib/facter/duplicate_user.rb
+++ b/lib/facter/duplicate_user.rb
@@ -4,6 +4,7 @@
 # Ensures no duplicate user names exist in /etc/passwd
 
 Facter.add('duplicate_user') do
+  confine osfamily: 'RedHat'
   setcode do
     Facter::Core::Execution.exec('/tmp/cis_scripts/dup_usr.sh')
   end

--- a/lib/facter/file_permission.rb
+++ b/lib/facter/file_permission.rb
@@ -4,5 +4,6 @@
 # Custom fact that contains specific installed files and the permissions they have
 
 Facter.add('file_permission') do
+  confine osfamily: 'RedHat'
   setcode 'rpm -Va --nomtime --nosize --nomd5 --nolinkto'
 end

--- a/lib/facter/forward_files.rb
+++ b/lib/facter/forward_files.rb
@@ -4,6 +4,7 @@
 # Contains any .forward files that may exist on a system
 
 Facter.add('forward_files') do
+  confine osfamily: 'RedHat'
   setcode do
     Facter::Core::Execution.exec('/tmp/cis_scripts/forward.sh')
   end

--- a/lib/facter/gnome_installed.rb
+++ b/lib/facter/gnome_installed.rb
@@ -3,6 +3,7 @@
 # gnome_installed.rb
 # Returns true if GNOME is installed
 Facter.add('gnome_installed') do
+  confine osfamily: 'RedHat'
   setcode do
     Facter::Core::Execution.exec('rpm -qa | grep gnome') != ''
   end

--- a/lib/facter/gpgkey.rb
+++ b/lib/facter/gpgkey.rb
@@ -3,5 +3,6 @@
 # gpgkey.rb
 
 Facter.add('gpgkey') do
+  confine osfamily: 'RedHat'
   setcode "rpm -q gpg-pubkey --qf '%{name}-%{version}-%{release} --> %{summary}\\n'"
 end

--- a/lib/facter/grub_pass.rb
+++ b/lib/facter/grub_pass.rb
@@ -3,5 +3,6 @@
 # grub_pass.rb
 
 Facter.add('grub_pass') do
+  confine osfamily: 'RedHat'
   setcode 'grep ^GRUB2_PASSWORD= /boot/grub2/*.cfg |awk -F= "{print \$1}"'
 end

--- a/lib/facter/home_directory.rb
+++ b/lib/facter/home_directory.rb
@@ -3,6 +3,7 @@
 # home_directory.rb
 
 Facter.add('home_directory') do
+  confine osfamily: 'RedHat'
   setcode do
     Facter::Core::Execution.exec('/tmp/cis_scripts/home_directory.sh')
   end

--- a/lib/facter/home_directory_owner.rb
+++ b/lib/facter/home_directory_owner.rb
@@ -4,6 +4,7 @@
 # Contains users that do not own home directories
 
 Facter.add('home_directory_owner') do
+  confine osfamily: 'RedHat'
   setcode do
     Facter::Core::Execution.exec('/tmp/cis_scripts/home_dir_own.sh')
   end

--- a/lib/facter/home_directory_permission.rb
+++ b/lib/facter/home_directory_permission.rb
@@ -4,6 +4,7 @@
 # Contains all user directories that have permissions less restrictive than 750
 
 Facter.add('home_directory_permission') do
+  confine osfamily: 'RedHat'
   setcode do
     Facter::Core::Execution.exec('/tmp/cis_scripts/home_dir_perm.sh')
   end

--- a/lib/facter/home_nodev.rb
+++ b/lib/facter/home_nodev.rb
@@ -4,6 +4,7 @@
 # Ensures the nodev option exists for the /home partition
 
 Facter.add('home_nodev') do
+  confine osfamily: 'RedHat'
   setcode do
     home = Facter::Core::Execution.exec('mount | grep /home')
     %r{nodev}.match(home)

--- a/lib/facter/issue_net.rb
+++ b/lib/facter/issue_net.rb
@@ -3,5 +3,6 @@
 # issue_net.rb
 
 Facter.add('issue_net') do
+  confine osfamily: 'RedHat'
   setcode 'egrep \'(\\\v|\\\r|\\\m|\\\s)\' /etc/issue.net'
 end

--- a/lib/facter/issue_os.rb
+++ b/lib/facter/issue_os.rb
@@ -3,5 +3,6 @@
 # issue_os.rb
 
 Facter.add('issue_os') do
+  confine osfamily: 'RedHat'
   setcode 'egrep \'(\\\v|\\\r|\\\m|\\\s)\' /etc/issue'
 end

--- a/lib/facter/local_users.rb
+++ b/lib/facter/local_users.rb
@@ -4,45 +4,59 @@
 # This fact contains a dictionary of local users and their value for max number of days between a password change
 Facter.add(:local_users) do
   confine osfamily: 'RedHat'
-  require 'time'
+  require 'date'
   setcode do
     local_users = {}
     user_list = Facter::Core::Execution.exec('egrep ^[^:]+:[^\!*] /etc/shadow | cut -d: -f1').split("\n")
     user_list.each do |user|
       local_users[user] = {}
 
-      maximum_number_of_days_between_password_change = Facter::Core::Execution.exec("chage --list #{user} | grep \"Max\"")
-      number_parser_max = %r{\d+}.match(maximum_number_of_days_between_password_change)
+# parse chage output for each user in /etc/shadow and create variables
+      last_password_change   = Facter::Core::Execution.exec("chage --list #{user} | grep \"Last password\"").match(/:\s*\K.*/).to_s
+      password_expires       = Facter::Core::Execution.exec("chage --list #{user} | grep \"Password expires\"").match(/:\s*\K.*/).to_s
+      password_inactive      = Facter::Core::Execution.exec("chage --list #{user} | grep \"Password inactive\"").match(/:\s*\K.*/).to_s
+      account_expires        = Facter::Core::Execution.exec("chage --list #{user} | grep \"Account expires\"").match(/:\s*\K.*/).to_s
+      minimum_number_of_days = Facter::Core::Execution.exec("chage --list #{user} | grep \"Minimum\"").match(/:\d*\K.*/)[0].to_i
+      maximum_number_of_days = Facter::Core::Execution.exec("chage --list #{user} | grep \"Maximum\"").match(/:\d*\K.*/)[0].to_i
+      warning_number_of_days = Facter::Core::Execution.exec("chage --list #{user} | grep \"warning\"").match(/:\d*\K.*/)[0].to_i
 
-      minimum_number_of_days_between_password_change = Facter::Core::Execution.exec("chage --list #{user} | grep \"Min\"")
-      number_parser_min = %r{\d+}.match(minimum_number_of_days_between_password_change)
+# set default values for facts
+      last_password_change_days = last_password_change
+      password_expires_days     = password_expires
+      password_inactive_days    = password_inactive
 
-      warning_number_of_days_between_password_change = Facter::Core::Execution.exec("chage --list #{user} | grep \"warn\"")
-      number_parser_warn = %r{\d+}.match(warning_number_of_days_between_password_change)
-
-      password_inactive = Facter::Core::Execution.exec("chage --list #{user} | grep \"inactive\"")
-      number_parser_inactive = %r{\d+}.match(password_inactive)
-
-      password_change = Facter::Core::Execution.exec("chage --list #{user} | grep \"Last\"")
-      number_parser_change = %r{\: ([^:]*)}.match(password_change)
-
-      begin
-        password_valid_date = Date.parse(number_parser_change[0]) <= Date.today
-      rescue ArgumentError
-        # TODO: do something with the password valid date if it doesn't parse.
-        # local_users = nil
-        password_valid_date = 'never'
-        next
+# check if password attribute not 'never', then determine days between now and then
+# and check if password is set prior to current date
+      if last_password_change    != "never"
+        last_password_change_days = (Date.today - Date.parse(last_password_change)).to_i
+        password_date_valid       = Date.parse(last_password_change) <= Date.today
       end
 
+      if password_expires       != "never"
+        password_expires_days    = (Date.parse(password_expires) - Date.today).to_i
+        if password_inactive    != "never"
+          password_inactive_days = (Date.parse(password_inactive) - Date.parse(password_expires)).to_i
+        end
+      end
+
+      if account_expires    != "never"
+        account_expires_days = (Date.parse(account_expires) - Date.today).to_i
+      else
+        account_expires_days = account_expires
+      end
+
+# create nested fact
       local_users[user] = {
-        'max_days_between_password_change'  => number_parser_max[0].to_i,
-        'min_days_between_password_change'  => number_parser_min[0].to_i,
-        'warn_days_between_password_change' => number_parser_warn[0].to_i,
-        'password_inactive'                 => number_parser_inactive ? number_parser_inactive[0].to_i : '',
-        'password_change'                   => password_valid_date,
+        'last_password_change_days'         => last_password_change_days,
+        'password_expires_days'             => password_expires_days,
+        'password_inactive_days'            => password_inactive_days,
+        'account_expires_days'              => account_expires_days,
+        'min_days_between_password_change'  => minimum_number_of_days,
+        'max_days_between_password_change'  => maximum_number_of_days,
+        'warn_days_between_password_change' => warning_number_of_days,
+        'password_date_valid'               => password_date_valid,
       }
-    end
+      end
     local_users
   end
 end

--- a/lib/facter/motd.rb
+++ b/lib/facter/motd.rb
@@ -4,5 +4,6 @@
 # Ensures MOTD is properly configured
 
 Facter.add('motd') do
+  confine osfamily: 'RedHat'
   setcode "egrep '(\\\\v|\\\\r|\\\\m|\\\\s)' /etc/motd"
 end

--- a/lib/facter/netrc_access.rb
+++ b/lib/facter/netrc_access.rb
@@ -4,6 +4,7 @@
 # Contains .netrc files that are either group or world accessible
 
 Facter.add('netrc_access') do
+  confine osfamily: 'RedHat'
   setcode do
     Facter::Core::Execution.exec('/tmp/cis_scripts/netrc_access.sh')
   end

--- a/lib/facter/netrc_files.rb
+++ b/lib/facter/netrc_files.rb
@@ -4,6 +4,7 @@
 # Contains any .netrc files on the system
 
 Facter.add('netrc_files') do
+  confine osfamily: 'RedHat'
   setcode do
     Facter::Core::Execution.exec('/tmp/cis_scripts/netrc.sh')
   end

--- a/lib/facter/nologin.rb
+++ b/lib/facter/nologin.rb
@@ -4,6 +4,7 @@
 # Ensures certain accounts used for managing applications cannot be accessed
 
 Facter.add('nologin') do
+  confine osfamily: 'RedHat'
   setcode do
     user_list = Facter::Core::Execution.exec(
       "egrep -v \"^\\+\" /etc/passwd | awk -F: '($1!=\"root\" && $1!=\"sync\" && $1!=\"shutdown\" && $1!=\"halt\" && $3<1000 && $7!=\"/sbin/nologin\" && $7!=\"/bin/false\") {print}'",

--- a/lib/facter/password_empty.rb
+++ b/lib/facter/password_empty.rb
@@ -3,5 +3,6 @@
 # password_empty.rb
 
 Facter.add('password_empty') do
+  confine osfamily: 'RedHat'
   setcode "cat /etc/shadow | awk -F: \'($2 == \"\" ) { print $1 \" does not have a password \"}\'"
 end

--- a/lib/facter/password_group_exist.rb
+++ b/lib/facter/password_group_exist.rb
@@ -4,6 +4,7 @@
 # Ensures groups that are defined in /etc/passwd file but not in the /etc/group file
 
 Facter.add('password_group_exist') do
+  confine osfamily: 'RedHat'
   setcode do
     Facter::Core::Execution.exec('/tmp/cis_scripts/pwd_group_exist.sh')
   end

--- a/lib/facter/plus_group.rb
+++ b/lib/facter/plus_group.rb
@@ -4,5 +4,6 @@
 # Contains "+" entries in /etc/group
 
 Facter.add('plus_group') do
+  confine osfamily: 'RedHat'
   setcode "grep '^\\+:' /etc/group"
 end

--- a/lib/facter/plus_passwd.rb
+++ b/lib/facter/plus_passwd.rb
@@ -4,5 +4,6 @@
 # Contains "+" entries in etc/passwd
 
 Facter.add('plus_passwd') do
+  confine osfamily: 'RedHat'
   setcode "grep '^\\+:' /etc/passwd"
 end

--- a/lib/facter/plus_shadow.rb
+++ b/lib/facter/plus_shadow.rb
@@ -4,5 +4,6 @@
 # Contains "+" entries in /etc/shadow
 
 Facter.add('plus_shadow') do
+  confine osfamily: 'RedHat'
   setcode "grep '^\\+:' /etc/shadow"
 end

--- a/lib/facter/rhost_files.rb
+++ b/lib/facter/rhost_files.rb
@@ -4,6 +4,7 @@
 # This fact contains any .rhost files that any users may posses
 
 Facter.add('rhost_files') do
+  confine osfamily: 'RedHat'
   setcode do
     Facter::Core::Execution.exec('/tmp/cis_scripts/rhost.sh')
   end

--- a/lib/facter/root_path.rb
+++ b/lib/facter/root_path.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 Facter.add('root_path') do
+  confine osfamily: 'RedHat'
   setcode do
     Facter::Core::Execution.exec('/tmp/cis_scripts/root_path.sh')
   end

--- a/lib/facter/root_uid.rb
+++ b/lib/facter/root_uid.rb
@@ -4,5 +4,6 @@
 # This contains all users that have a UID of "0"
 
 Facter.add('root_uid') do
+  confine osfamily: 'RedHat'
   setcode "cat /etc/passwd | awk -F: '($3 == 0) { print $1 }"
 end

--- a/lib/facter/sgid_files.rb
+++ b/lib/facter/sgid_files.rb
@@ -4,5 +4,6 @@
 # This fact contains SGID files, which are nearly identical to SUID files mentioned in cis_1_1_13
 
 Facter.add('sgid_files') do
+  confine osfamily: 'RedHat'
   setcode "df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -type f -perm -2000"
 end

--- a/lib/facter/shm_nodev.rb
+++ b/lib/facter/shm_nodev.rb
@@ -4,6 +4,7 @@
 # Ensures the nodev option is enabled on the /dev/shm partition
 
 Facter.add('shm_nodev') do
+  confine osfamily: 'RedHat'
   setcode do
     shm = Facter::Core::Execution.exec('mount | grep /dev/shm')
     if shm.match?(%r{nodev})

--- a/lib/facter/shm_noexec.rb
+++ b/lib/facter/shm_noexec.rb
@@ -4,6 +4,7 @@
 # Ensures the noexec option is enabled on the /deev/shm partition
 
 Facter.add('shm_noexec') do
+  confine osfamily: 'RedHat'
   setcode do
     shmne = Facter::Core::Execution.exec('mount | grep /dev/shm')
     if shmne.match?(%r{noexec})

--- a/lib/facter/shm_nosuid.rb
+++ b/lib/facter/shm_nosuid.rb
@@ -4,6 +4,7 @@
 # Ensures the nosuid option is enabled for the /dev/shm partition
 
 Facter.add('shm_nosuid') do
+  confine osfamily: 'RedHat'
   setcode do
     shmns = Facter::Core::Execution.exec('mount | grep /dev/shm')
     if shmns.match?(%r{nosuid})

--- a/lib/facter/sticky_ww.rb
+++ b/lib/facter/sticky_ww.rb
@@ -2,5 +2,6 @@
 
 # sticky_ww.rb
 Facter.add('sticky_ww') do
+  confine osfamily: 'RedHat'
   setcode "df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -type d -perm -0002 -a ! -perm -1000 2>/dev/null"
 end

--- a/lib/facter/suid_files.rb
+++ b/lib/facter/suid_files.rb
@@ -4,5 +4,6 @@
 # This custom fact contains all SUID files on a system, which allow users to execute with root privileges
 
 Facter.add('suid_files') do
+  confine osfamily: 'RedHat'
   setcode "df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -type f -perm -4000"
 end

--- a/lib/facter/unconf_daemons.rb
+++ b/lib/facter/unconf_daemons.rb
@@ -3,5 +3,6 @@
 # unconf_daemons.rb
 # Ensures no unconfined daemons exist
 Facter.add('unconf_daemons') do
+  confine osfamily: 'RedHat'
   setcode "ps -eZ | egrep \"initrc\" | egrep -vw \"tr|ps|egrep|bash|awk\" | tr ':' ' ' | awk '{ print $NF }'"
 end

--- a/lib/facter/unowned_group_files.rb
+++ b/lib/facter/unowned_group_files.rb
@@ -4,5 +4,6 @@
 # This custom fact contains all files that are not owned by groups listed in the system
 
 Facter.add('unowned_group_files') do
+  confine osfamily: 'RedHat'
   setcode "df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -nogroup"
 end

--- a/lib/facter/unowned_user_files.rb
+++ b/lib/facter/unowned_user_files.rb
@@ -4,5 +4,6 @@
 # This custom fact contains all files that are not owned by users listed in the system
 
 Facter.add('unowned_user_files') do
+  confine osfamily: 'RedHat'
   setcode "df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -nouser"
 end

--- a/lib/facter/var_log_audit.rb
+++ b/lib/facter/var_log_audit.rb
@@ -4,6 +4,7 @@
 # Ensures a seperate partition exists for /var/log/audit
 
 Facter.add('var_log_audit') do
+  confine osfamily: 'RedHat'
   # rubocop:disable Style/StringLiterals
   setcode do
     Facter::Core::Execution.exec("mount | grep \"/var/log/audit\"")

--- a/lib/facter/world_writable.rb
+++ b/lib/facter/world_writable.rb
@@ -5,5 +5,6 @@
 # which are security risks
 
 Facter.add('world_writable') do
+  confine osfamily: 'RedHat'
   setcode "df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -type f -perm -0002"
 end

--- a/lib/facter/world_writable_redhat.rb
+++ b/lib/facter/world_writable_redhat.rb
@@ -5,5 +5,6 @@
 # which are security risks
 
 Facter.add('world_writable_redhat') do
+  confine osfamily: 'RedHat'
   setcode 'df --local -P | awk {&#039;if (NR!=1) print $6&#039;} | xargs -I &#039;{}&#039; find &#039;{}&#039; -xdev -type f -perm -0002'
 end

--- a/lib/facter/xorg_x11_packages.rb
+++ b/lib/facter/xorg_x11_packages.rb
@@ -3,6 +3,7 @@
 # This fact xorg_x11_packages returns an array of installed packages that start with xorg-x11*
 #
 Facter.add('xorg_x11_packages') do
+  confine osfamily: 'RedHat'
   confine kernel: :linux
   setcode do
     package_list = Facter::Core::Execution.exec('rpm -qa xorg-x11*')

--- a/lib/facter/yum_repolist.rb
+++ b/lib/facter/yum_repolist.rb
@@ -3,5 +3,6 @@
 # Yum_repolist.rb
 
 Facter.add('yum_repolist') do
+  confine osfamily: 'RedHat'
   setcode 'yum repolist -d0 |grep -ve "repo id" | awk "{print \$1}" | sed s/^!//g'
 end

--- a/manifests/centos7.pp
+++ b/manifests/centos7.pp
@@ -377,7 +377,7 @@ class secure_linux_cis::centos7 (
   # 4.1.17
   include ::secure_linux_cis::redhat7::cis_4_1_17
   # # 4.1.18
-  # include ::secure_linux_cis::redhat7::cis_4_1_18
+  include ::secure_linux_cis::redhat7::cis_4_1_18
 
   # 4.2.1.1
   class { '::secure_linux_cis::redhat7::cis_4_2_1_1':

--- a/manifests/redhat7/cis_4_1_10.pp
+++ b/manifests/redhat7/cis_4_1_10.pp
@@ -32,37 +32,37 @@ class secure_linux_cis::redhat7::cis_4_1_10 (
 
       file_line { 'audit.rules access 1':
         ensure => present,
-        path   => '/etc/audit/audit.rules',
+        path   => '/etc/audit/rules.d/audit.rules',
         line   => '-a always,exit -F arch=b64 -S chmod -S fchmod -S fchmodat -F auid>=1000 -F auid!=4294967295 -k perm_mod',
       }
 
       file_line { 'audit.rules access 2':
         ensure => present,
-        path   => '/etc/audit/audit.rules',
+        path   => '/etc/audit/rules.d/audit.rules',
         line   => '-a always,exit -F arch=b32 -S chmod -S fchmod -S fchmodat -F auid>=1000 -F auid!=4294967295 -k perm_mod',
       }
 
       file_line { 'audit.rules access 3':
         ensure => present,
-        path   => '/etc/audit/audit.rules',
+        path   => '/etc/audit/rules.d/audit.rules',
         line   => '-a always,exit -F arch=b64 -S chown -S fchown -S fchownat -S lchown -F auid>=1000 -F auid!=4294967295 -k perm_mod',
       }
 
       file_line { 'audit.rules access 4':
         ensure => present,
-        path   => '/etc/audit/audit.rules',
+        path   => '/etc/audit/rules.d/audit.rules',
         line   => '-a always,exit -F arch=b32 -S chown -S fchown -S fchownat -S lchown -F auid>=1000 -F auid!=4294967295 -k perm_mod',
       }
 
       file_line { 'audit.rules access 5':
         ensure => present,
-        path   => '/etc/audit/audit.rules',
+        path   => '/etc/audit/rules.d/audit.rules',
         line   => '-a always,exit -F arch=b64 -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S lremovexattr -S fremovexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod', # lint:ignore:140chars
       }
 
       file_line { 'audit.rules access 6':
         ensure => present,
-        path   => '/etc/audit/audit.rules',
+        path   => '/etc/audit/rules.d/audit.rules',
         line   => '-a always,exit -F arch=b32 -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S lremovexattr -S fremovexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod', # lint:ignore:140chars
       }
 
@@ -73,19 +73,19 @@ class secure_linux_cis::redhat7::cis_4_1_10 (
 
       file_line { 'audit.rules access 1':
         ensure => present,
-        path   => '/etc/audit/audit.rules',
+        path   => '/etc/audit/rules.d/audit.rules',
         line   => '-a always,exit -F arch=b32 -S chmod -S fchmod -S fchmodat -F auid>=1000 -F auid!=4294967295 -k perm_mod',
       }
 
       file_line { 'audit.rules access 2':
         ensure => present,
-        path   => '/etc/audit/audit.rules',
+        path   => '/etc/audit/rules.d/audit.rules',
         line   => '-a always,exit -F arch=b32 -S chown -S fchown -S fchownat -S lchown -F auid>=1000 -F auid!=4294967295 -k perm_mod',
       }
 
       file_line { 'audit.rules access 3':
         ensure => present,
-        path   => '/etc/audit/audit.rules',
+        path   => '/etc/audit/rules.d/audit.rules',
         line   => '-a always,exit -F arch=b32 -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S lremovexattr -S fremovexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod', # lint:ignore:140chars
       }
     }

--- a/manifests/redhat7/cis_4_1_11.pp
+++ b/manifests/redhat7/cis_4_1_11.pp
@@ -30,25 +30,25 @@ class secure_linux_cis::redhat7::cis_4_1_11 (
 
       file_line { 'audit.rules file access 1':
         ensure => present,
-        path   => '/etc/audit/audit.rules',
+        path   => '/etc/audit/rules.d/audit.rules',
         line   => '-a always,exit -F arch=b64 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access', # lint:ignore:140chars
       }
 
       file_line { 'audit.rules file access 2':
         ensure => present,
-        path   => '/etc/audit/audit.rules',
+        path   => '/etc/audit/rules.d/audit.rules',
         line   => '-a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access', # lint:ignore:140chars
       }
 
       file_line { 'audit.rules file access 3':
         ensure => present,
-        path   => '/etc/audit/audit.rules',
+        path   => '/etc/audit/rules.d/audit.rules',
         line   => '-a always,exit -F arch=b64 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access', # lint:ignore:140chars
       }
 
       file_line { 'audit.rules file access 4':
         ensure => present,
-        path   => '/etc/audit/audit.rules',
+        path   => '/etc/audit/rules.d/audit.rules',
         line   => '-a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access', # lint:ignore:140chars
       }
     }
@@ -58,13 +58,13 @@ class secure_linux_cis::redhat7::cis_4_1_11 (
 
       file_line { 'audit.rules file access 1':
         ensure => present,
-        path   => '/etc/audit/audit.rules',
+        path   => '/etc/audit/rules.d/audit.rules',
         line   => '-a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access', # lint:ignore:140chars
       }
 
       file_line { 'audit.rules file access 2':
         ensure => present,
-        path   => '/etc/audit/audit.rules',
+        path   => '/etc/audit/rules.d/audit.rules',
         line   => '-a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access', # lint:ignore:140chars
       }
     }

--- a/manifests/redhat7/cis_4_1_13.pp
+++ b/manifests/redhat7/cis_4_1_13.pp
@@ -35,13 +35,13 @@ class secure_linux_cis::redhat7::cis_4_1_13 (
 
       file_line { 'audit.rules mounts 1':
         ensure => present,
-        path   => '/etc/audit/audit.rules',
+        path   => '/etc/audit/rules.d/audit.rules',
         line   => '-a always,exit -F arch=b64 -S mount -F auid>=1000 -F auid!=4294967295 -k mounts',
       }
 
       file_line { 'audit.rules mounts 2':
         ensure => present,
-        path   => '/etc/audit/audit.rules',
+        path   => '/etc/audit/rules.d/audit.rules',
         line   => '-a always,exit -F arch=b32 -S mount -F auid>=1000 -F auid!=4294967295 -k mounts',
       }
     }
@@ -50,7 +50,7 @@ class secure_linux_cis::redhat7::cis_4_1_13 (
 
       file_line { 'audit.rules mounts 1':
         ensure => present,
-        path   => '/etc/audit/audit.rules',
+        path   => '/etc/audit/rules.d/audit.rules',
         line   => '-a always,exit -F arch=b32 -S mount -F auid>=1000 -F auid!=4294967295 -k mounts',
       }
     }

--- a/manifests/redhat7/cis_4_1_14.pp
+++ b/manifests/redhat7/cis_4_1_14.pp
@@ -30,13 +30,13 @@ class secure_linux_cis::redhat7::cis_4_1_14 (
 
       file_line { 'audit.rules file deletion 1':
         ensure => present,
-        path   => '/etc/audit/audit.rules',
+        path   => '/etc/audit/rules.d/audit.rules',
         line   => '-a always,exit -F arch=b64 -S unlink -S unlinkat -S rename -S renameat -F auid>=1000 -F auid!=4294967295 -k delete',
       }
 
       file_line { 'audit.rules file deletion 2':
         ensure => present,
-        path   => '/etc/audit/audit.rules',
+        path   => '/etc/audit/rules.d/audit.rules',
         line   => '-a always,exit -F arch=b32 -S unlink -S unlinkat -S rename -S renameat -F auid>=1000 -F auid!=4294967295 -k delete',
       }
     }
@@ -46,7 +46,7 @@ class secure_linux_cis::redhat7::cis_4_1_14 (
 
       file_line { 'audit.rules file deletion 1':
         ensure => present,
-        path   => '/etc/audit/audit.rules',
+        path   => '/etc/audit/rules.d/audit.rules',
         line   => '-a always,exit -F arch=b32 -S unlink -S unlinkat -S rename -S renameat -F auid>=1000 -F auid!=4294967295 -k delete',
       }
     }

--- a/manifests/redhat7/cis_4_1_15.pp
+++ b/manifests/redhat7/cis_4_1_15.pp
@@ -25,13 +25,13 @@ class secure_linux_cis::redhat7::cis_4_1_15 (
 
     file_line { 'audit.rules sudoers 1':
       ensure => present,
-      path   => '/etc/audit/audit.rules',
+      path   => '/etc/audit/rules.d/audit.rules',
       line   => '-w /etc/sudoers -p wa -k scope',
     }
 
     file_line { 'audit.rules sudoers 2':
       ensure => present,
-      path   => '/etc/audit/audit.rules',
+      path   => '/etc/audit/rules.d/audit.rules',
       line   => '-w /etc/sudoers.d/ -p wa -k scope',
     }
   }

--- a/manifests/redhat7/cis_4_1_16.pp
+++ b/manifests/redhat7/cis_4_1_16.pp
@@ -28,7 +28,7 @@ class secure_linux_cis::redhat7::cis_4_1_16 (
 
     file_line { 'audit.rules sudo.log 1':
       ensure => present,
-      path   => '/etc/audit/audit.rules',
+      path   => '/etc/audit/rules.d/audit.rules',
       line   => '-w /var/log/sudo.log -p wa -k actions',
     }
   }

--- a/manifests/redhat7/cis_4_1_17.pp
+++ b/manifests/redhat7/cis_4_1_17.pp
@@ -33,25 +33,25 @@ class secure_linux_cis::redhat7::cis_4_1_17 (
 
       file_line { 'audit.rules kernel module 1':
         ensure => present,
-        path   => '/etc/audit/audit.rules',
+        path   => '/etc/audit/rules.d/audit.rules',
         line   => '-w /sbin/insmod -p x -k modules',
       }
 
       file_line { 'audit.rules kernel module 2':
         ensure => present,
-        path   => '/etc/audit/audit.rules',
+        path   => '/etc/audit/rules.d/audit.rules',
         line   => '-w /sbin/rmmod -p x -k modules',
       }
 
       file_line { 'audit.rules kernel module 3':
         ensure => present,
-        path   => '/etc/audit/audit.rules',
+        path   => '/etc/audit/rules.d/audit.rules',
         line   => '-w /sbin/modprobe -p x -k modules',
       }
 
       file_line { 'audit.rules kernel module 4':
         ensure => present,
-        path   => '/etc/audit/audit.rules',
+        path   => '/etc/audit/rules.d/audit.rules',
         line   => '-a always,exit -F arch=b64 -S init_module -S delete_module -k modules',
       }
     }
@@ -61,25 +61,25 @@ class secure_linux_cis::redhat7::cis_4_1_17 (
 
       file_line { 'audit.rules kernel module 1':
         ensure => present,
-        path   => '/etc/audit/audit.rules',
+        path   => '/etc/audit/rules.d/audit.rules',
         line   => '-w /sbin/insmod -p x -k modules',
       }
 
       file_line { 'audit.rules kernel module 2':
         ensure => present,
-        path   => '/etc/audit/audit.rules',
+        path   => '/etc/audit/rules.d/audit.rules',
         line   => '-w /sbin/rmmod -p x -k modules',
       }
 
       file_line { 'audit.rules kernel module 3':
         ensure => present,
-        path   => '/etc/audit/audit.rules',
+        path   => '/etc/audit/rules.d/audit.rules',
         line   => '-w /sbin/modprobe -p x -k modules',
       }
 
       file_line { 'audit.rules kernel module 4':
         ensure => present,
-        path   => '/etc/audit/audit.rules',
+        path   => '/etc/audit/rules.d/audit.rules',
         line   => '-a always,exit -F arch=b32 -S init_module -S delete_module -k modules',
       }
     }

--- a/manifests/redhat7/cis_4_1_18.pp
+++ b/manifests/redhat7/cis_4_1_18.pp
@@ -1,8 +1,32 @@
-# @summary A short summary of the purpose of this class
+# 4.1.18 Ensure the audit configuration is immutable (Scored)
 #
-# A description of what this class does
+# Description: 
+# Set system audit so that audit rules cannot be modified with auditctl.
+# Setting the flag "-e 2" forces audit to be put in immutable mode. Audit changes can only be made
+# on system reboot. 
+#
+# Rationale: 
+# In immutable mode, unauthorized users cannot execute changes to the audit system
+# to potentially hide malicious activity and then put the audit rules back.
+# Users would most likely notice a system reboot and that could alert administrators of an attempt
+# to make unauthorized audit changes. 
+#
+# @summary 4.1.18 Ensure the audit configuration is immutable (Scored)
+#
+# @param enforced Should this rule be enforced
 #
 # @example
 #   include secure_linux_cis::redhat7::cis_4_1_18
-class secure_linux_cis::redhat7::cis_4_1_18 {
+class secure_linux_cis::redhat7::cis_4_1_18 (
+  Boolean $enforced = true,
+){
+
+  if $enforced {
+
+    file_line { 'audit.rules make immutable':
+      ensure => present,
+      path   => '/etc/audit/rules.d/audit.rules',
+      line   => '-e 2',
+    }
+  }
 }

--- a/manifests/redhat7/cis_4_1_4.pp
+++ b/manifests/redhat7/cis_4_1_4.pp
@@ -29,31 +29,31 @@ class secure_linux_cis::redhat7::cis_4_1_4 (
 
       file_line { 'audit.rules time 1':
         ensure => present,
-        path   => '/etc/audit/audit.rules',
+        path   => '/etc/audit/rules.d/audit.rules',
         line   => '-a always,exit -F arch=b64 -S adjtimex -S settimeofday -k time-change',
       }
 
       file_line { 'audit.rules time 2':
         ensure => present,
-        path   => '/etc/audit/audit.rules',
-        line   => '-a always,exit -F arch=b32 -S adjtimex -S settimeofday -S stime -k timechange',
+        path   => '/etc/audit/rules.d/audit.rules',
+        line   => '-a always,exit -F arch=b32 -S adjtimex -S settimeofday -S stime -k time-change',
       }
 
       file_line { 'audit.rules time 3':
         ensure => present,
-        path   => '/etc/audit/audit.rules',
+        path   => '/etc/audit/rules.d/audit.rules',
         line   => '-a always,exit -F arch=b64 -S clock_settime -k time-change',
       }
 
       file_line { 'audit.rules time 4':
         ensure => present,
-        path   => '/etc/audit/audit.rules',
+        path   => '/etc/audit/rules.d/audit.rules',
         line   => '-a always,exit -F arch=b32 -S clock_settime -k time-change',
       }
 
       file_line { 'audit.rules time 5':
         ensure => present,
-        path   => '/etc/audit/audit.rules',
+        path   => '/etc/audit/rules.d/audit.rules',
         line   => '-w /etc/localtime -p wa -k time-change',
       }
 
@@ -64,19 +64,19 @@ class secure_linux_cis::redhat7::cis_4_1_4 (
 
       file_line { 'audit.rules time 1':
         ensure => present,
-        path   => '/etc/audit/audit.rules',
-        line   => '-a always,exit -F arch=b32 -S adjtimex -S settimeofday -S stime -k timechange',
+        path   => '/etc/audit/rules.d/audit.rules',
+        line   => '-a always,exit -F arch=b32 -S adjtimex -S settimeofday -S stime -k time-change',
       }
 
       file_line { 'audit.rules time 2':
         ensure => present,
-        path   => '/etc/audit/audit.rules',
+        path   => '/etc/audit/rules.d/audit.rules',
         line   => '-a always,exit -F arch=b32 -S clock_settime -k time-change',
       }
 
       file_line { 'audit.rules time 3':
         ensure => present,
-        path   => '/etc/audit/audit.rules',
+        path   => '/etc/audit/rules.d/audit.rules',
         line   => '-w /etc/localtime -p wa -k time-change',
       }
     }

--- a/manifests/redhat7/cis_4_1_5.pp
+++ b/manifests/redhat7/cis_4_1_5.pp
@@ -26,31 +26,31 @@ class secure_linux_cis::redhat7::cis_4_1_5 (
 
     file_line { 'audit.rules user/group 1':
       ensure => present,
-      path   => '/etc/audit/audit.rules',
+      path   => '/etc/audit/rules.d/audit.rules',
       line   => '-w /etc/group -p wa -k identity',
     }
 
     file_line { 'audit.rules user/group 2':
       ensure => present,
-      path   => '/etc/audit/audit.rules',
+      path   => '/etc/audit/rules.d/audit.rules',
       line   => '-w /etc/passwd -p wa -k identity',
     }
 
     file_line { 'audit.rules user/group 3':
       ensure => present,
-      path   => '/etc/audit/audit.rules',
+      path   => '/etc/audit/rules.d/audit.rules',
       line   => '-w /etc/gshadow -p wa -k identity',
     }
 
     file_line { 'audit.rules user/group 4':
       ensure => present,
-      path   => '/etc/audit/audit.rules',
+      path   => '/etc/audit/rules.d/audit.rules',
       line   => '-w /etc/shadow -p wa -k identity',
     }
 
     file_line { 'audit.rules user/group 5':
       ensure => present,
-      path   => '/etc/audit/audit.rules',
+      path   => '/etc/audit/rules.d/audit.rules',
       line   => '-w /etc/security/opasswd -p wa -k identity',
     }
   }

--- a/manifests/redhat7/cis_4_1_6.pp
+++ b/manifests/redhat7/cis_4_1_6.pp
@@ -39,43 +39,43 @@ class secure_linux_cis::redhat7::cis_4_1_6 (
 
       file_line { 'audit.rules network 1':
         ensure => present,
-        path   => '/etc/audit/audit.rules',
+        path   => '/etc/audit/rules.d/audit.rules',
         line   => '-a always,exit -F arch=b64 -S sethostname -S setdomainname -k system-locale',
       }
 
       file_line { 'audit.rules network 2':
         ensure => present,
-        path   => '/etc/audit/audit.rules',
+        path   => '/etc/audit/rules.d/audit.rules',
         line   => '-a always,exit -F arch=b32 -S sethostname -S setdomainname -k system-locale',
       }
 
       file_line { 'audit.rules network 3':
         ensure => present,
-        path   => '/etc/audit/audit.rules',
+        path   => '/etc/audit/rules.d/audit.rules',
         line   => '-w /etc/issue -p wa -k system-locale',
       }
 
       file_line { 'audit.rules network 4':
         ensure => present,
-        path   => '/etc/audit/audit.rules',
+        path   => '/etc/audit/rules.d/audit.rules',
         line   => '-w /etc/issue.net -p wa -k system-locale',
       }
 
       file_line { 'audit.rules network 5':
         ensure => present,
-        path   => '/etc/audit/audit.rules',
+        path   => '/etc/audit/rules.d/audit.rules',
         line   => '-w /etc/hosts -p wa -k system-locale',
       }
 
       file_line { 'audit.rules network 6':
         ensure => present,
-        path   => '/etc/audit/audit.rules',
+        path   => '/etc/audit/rules.d/audit.rules',
         line   => '-w /etc/sysconfig/network -p wa -k system-locale',
       }
 
       file_line { 'audit.rules network 7':
         ensure => present,
-        path   => '/etc/audit/audit.rules',
+        path   => '/etc/audit/rules.d/audit.rules',
         line   => '-w /etc/sysconfig/network-scripts/ -p wa -k system-locale',
       }
     }
@@ -85,37 +85,37 @@ class secure_linux_cis::redhat7::cis_4_1_6 (
 
       file_line { 'audit.rules network 1':
         ensure => present,
-        path   => '/etc/audit/audit.rules',
+        path   => '/etc/audit/rules.d/audit.rules',
         line   => '-a always,exit -F arch=b32 -S sethostname -S setdomainname -k system-locale',
       }
 
       file_line { 'audit.rules network 2':
         ensure => present,
-        path   => '/etc/audit/audit.rules',
+        path   => '/etc/audit/rules.d/audit.rules',
         line   => '-w /etc/issue -p wa -k system-locale',
       }
 
       file_line { 'audit.rules network 3':
         ensure => present,
-        path   => '/etc/audit/audit.rules',
+        path   => '/etc/audit/rules.d/audit.rules',
         line   => '-w /etc/issue.net -p wa -k system-locale',
       }
 
       file_line { 'audit.rules network 4':
         ensure => present,
-        path   => '/etc/audit/audit.rules',
+        path   => '/etc/audit/rules.d/audit.rules',
         line   => '-w /etc/hosts -p wa -k system-locale',
       }
 
       file_line { 'audit.rules network 5':
         ensure => present,
-        path   => '/etc/audit/audit.rules',
+        path   => '/etc/audit/rules.d/audit.rules',
         line   => '-w /etc/sysconfig/network -p wa -k system-locale',
       }
 
       file_line { 'audit.rules network 6':
         ensure => present,
-        path   => '/etc/audit/audit.rules',
+        path   => '/etc/audit/rules.d/audit.rules',
         line   => '-w /etc/sysconfig/network-scripts/ -p wa -k system-locale',
       }
     }

--- a/manifests/redhat7/cis_4_1_7.pp
+++ b/manifests/redhat7/cis_4_1_7.pp
@@ -24,13 +24,13 @@ class secure_linux_cis::redhat7::cis_4_1_7 (
 
     file_line { 'audit.rules selinux 1':
       ensure => present,
-      path   => '/etc/audit/audit.rules',
+      path   => '/etc/audit/rules.d/audit.rules',
       line   => '-w /etc/selinux/ -p wa -k MAC-policy',
     }
 
     file_line { 'audit.rules selinux 2':
       ensure => present,
-      path   => '/etc/audit/audit.rules',
+      path   => '/etc/audit/rules.d/audit.rules',
       line   => '-w /usr/share/selinux/ -p wa -k MAC-policy',
     }
   }

--- a/manifests/redhat7/cis_4_1_8.pp
+++ b/manifests/redhat7/cis_4_1_8.pp
@@ -24,13 +24,13 @@ class secure_linux_cis::redhat7::cis_4_1_8 (
 
     file_line { 'audit.rules login/logout 1':
       ensure => present,
-      path   => '/etc/audit/audit.rules',
+      path   => '/etc/audit/rules.d/audit.rules',
       line   => '-w /var/log/lastlog -p wa -k logins',
     }
 
     file_line { 'audit.rules login/logout 2':
       ensure => present,
-      path   => '/etc/audit/audit.rules',
+      path   => '/etc/audit/rules.d/audit.rules',
       line   => '-w /var/run/faillock/ -p wa -k logins',
     }
   }

--- a/manifests/redhat7/cis_4_1_9.pp
+++ b/manifests/redhat7/cis_4_1_9.pp
@@ -27,19 +27,19 @@ class secure_linux_cis::redhat7::cis_4_1_9 (
 
     file_line { 'audit.rules session 1':
       ensure => present,
-      path   => '/etc/audit/audit.rules',
+      path   => '/etc/audit/rules.d/audit.rules',
       line   => '-w /var/run/utmp -p wa -k session',
     }
 
     file_line { 'audit.rules session 2':
       ensure => present,
-      path   => '/etc/audit/audit.rules',
+      path   => '/etc/audit/rules.d/audit.rules',
       line   => '-w /var/log/wtmp -p wa -k logins',
     }
 
     file_line { 'audit.rules session 3':
       ensure => present,
-      path   => '/etc/audit/audit.rules',
+      path   => '/etc/audit/rules.d/audit.rules',
       line   => '-w /var/log/btmp -p wa -k logins',
     }
   }

--- a/manifests/redhat7/cis_5_4_1_1.pp
+++ b/manifests/redhat7/cis_5_4_1_1.pp
@@ -11,9 +11,6 @@
 #
 # @summary 5.4.1.1 Ensure password expiration is 365 days or less (Scored)
 #
-# @param enforced Should this rule be enforced
-# @param pass_max_days Password maximum days
-#
 # @example
 #   include secure_linux_cis::redhat7::cis_5_4_1_1
 class secure_linux_cis::redhat7::cis_5_4_1_1 (
@@ -38,7 +35,7 @@ class secure_linux_cis::redhat7::cis_5_4_1_1 (
 
       $facts['local_users'].each |String $user, Hash $attributes| {
 
-        if !($attributes['max_days_between_password_change'].empty) {
+        if $attributes['password_expires_days'] != 'never' {
 
           if $attributes['max_days_between_password_change'] != $pass_max_days {
             exec { "/bin/chage --maxdays ${pass_max_days} ${user}": }

--- a/manifests/redhat7/cis_5_4_1_2.pp
+++ b/manifests/redhat7/cis_5_4_1_2.pp
@@ -11,9 +11,6 @@
 #
 # @summary 5.4.1.2 Ensure minimum days between password changes is 7 or more (Scored)
 #
-# @param enforced Should this rule be enforced
-# @param pass_min_days Password minimum days
-#
 # @example
 #   include secure_linux_cis::redhat7::cis_5_4_1_2
 class secure_linux_cis::redhat7::cis_5_4_1_2 (
@@ -35,9 +32,9 @@ class secure_linux_cis::redhat7::cis_5_4_1_2 (
         match  => '^#?PASS_MIN_DAYS',
       }
 
-      $facts['local_users'].each |String $user, Hash $attributes| {
+        $facts['local_users'].each |String $user, Hash $attributes| {
 
-        if !($attributes['max_days_between_password_change'].empty) {
+        if $attributes['password_expires_days'] != 'never' {
 
           if $attributes['min_days_between_password_change'] != $pass_min_days {
             exec { "/bin/chage --mindays ${pass_min_days} ${user}": }

--- a/manifests/redhat7/cis_5_4_1_3.pp
+++ b/manifests/redhat7/cis_5_4_1_3.pp
@@ -10,9 +10,6 @@
 #
 # @summary 5.4.1.3 Ensure password expiration warning days is 7 or more (Scored)
 #
-# @param enforced Should this rule be enforced
-# @param pass_warn_days Password warning days
-#
 # @example
 #   include secure_linux_cis::redhat7::cis_5_4_1_3
 class secure_linux_cis::redhat7::cis_5_4_1_3 (
@@ -34,9 +31,9 @@ class secure_linux_cis::redhat7::cis_5_4_1_3 (
         match  => '^#?PASS_WARN_AGE',
       }
 
-      $facts['local_users'].each |String $user, Hash $attributes| {
+        $facts['local_users'].each |String $user, Hash $attributes| {
 
-        if !($attributes['max_days_between_password_change'].empty) {
+        if $attributes['password_expires_days'] != 'never' {
 
           if $attributes['warn_days_between_password_change'] != $pass_warn_days {
             exec { "/bin/chage --warndays ${pass_warn_days} ${user}": }

--- a/manifests/redhat7/cis_5_4_1_4.pp
+++ b/manifests/redhat7/cis_5_4_1_4.pp
@@ -28,14 +28,11 @@ class secure_linux_cis::redhat7::cis_5_4_1_4 (
 
       $facts['local_users'].each |String $user, Hash $attributes| {
 
-        if !($attributes['max_days_between_password_change'].empty) {
+        if $attributes['password_expires_days'] != 'never' {
 
-          unless $attributes['if_never_conditional'] == 'never' {
+          if $attributes['password_inactive_days'] != $pass_inactive_days {
 
-            if $attributes['number_parser_inactive'] != $pass_inactive_days {
-
-              exec { "/bin/chage --inactive ${pass_inactive_days} ${user}": }
-            }
+            exec { "/bin/chage --inactive ${pass_inactive_days} ${user}": }
           }
         }
       }

--- a/manifests/redhat7/cis_5_4_1_5.pp
+++ b/manifests/redhat7/cis_5_4_1_5.pp
@@ -8,11 +8,9 @@
 #
 # @summary 5.4.1.5 Ensure all users last password change date is in the past (Scored)
 #
-# @param enforced Should this rule be enforced
-#
 # @example
 #   include secure_linux_cis::redhat7::cis_5_4_1_5
-class secure_linux_cis::redhat7::cis_5_4_1_5 (
+  class secure_linux_cis::redhat7::cis_5_4_1_5 (
   Boolean $enforced = true,
 ) {
 
@@ -24,7 +22,7 @@ class secure_linux_cis::redhat7::cis_5_4_1_5 (
     else {
       $facts['local_users'].each |String $user, Hash $attributes| {
 
-        if !$attributes['password_change'] {
+        if !$attributes['password_date_valid'] {
           # fail("User ${user} has a password last changed date in the future. Please investigate.")
           notify { "plcd ${user}":
             message  => 'Not in compliance with CIS 5.4.1.5 (Scored). We believe the user has a password last changed date in the future. Please investigate.', #lint:ignore:140chars

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "fervid-secure_linux_cis",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "author": "Fervid",
   "summary": "This module hardens Linux servers to CIS security compliance",
   "license": "Apache-2.0",


### PR DESCRIPTION
I have refactored and tested the local_users fact to overcome an issue with password_inactive, and expanded child facts.  Classes that uses this fact have also been refactored and tested.

Also, I have changed the writing of auditd rules to /etc/audit/rules.d/audit.rules to make the rules persistent across reboots, as they were getting purged and rewritten by puppet otherwise.

Re-added the confine to facts and some other minor fixes.