### PR TITLE
Add file test for tcp6 to prevent warning if tcp6 disabled

### DIFF
--- a/lib/facter/smtp_listen.rb
+++ b/lib/facter/smtp_listen.rb
@@ -15,12 +15,14 @@ Facter.add('smtp_listen') do
       next unless i[2] =~ %r{^0{8}:0{4}$} # Only LISTEN
       smtp << 'There is a process listening on TCP port 25'
     end
-    File.open('/proc/net/tcp6').each do |i|
-      i = i.split(' ')
-      next unless i[1] =~ %r{:0016$} # Skip anything but smtp
-      next if i[1] =~ %r{^00000000000000000000000001000000:} # Skip localhost
-      next unless i[2] =~ %r{^0{32}:0{4}$} # only LISTEN
-      smtp << 'There is a process listening on TCP port 25 (IPv6)'
+    if(File.exist?('/proc/net/tcp6'))
+      File.open('/proc/net/tcp6').each do |i|
+        i = i.split(' ')
+        next unless i[1] =~ %r{:0016$} # Skip anything but smtp
+        next if i[1] =~ %r{^00000000000000000000000001000000:} # Skip localhost
+        next unless i[2] =~ %r{^0{32}:0{4}$} # only LISTEN
+        smtp << 'There is a process listening on TCP port 25 (IPv6)'
+      end
     end
     smtp
   end


### PR DESCRIPTION
If tcp6 has been disabled and the tcp6 file is not available, this error is rasied:

Info: Loading facts

Error: Facter: error while resolving custom fact "smtp_listen": No such file or directory @ rb_sysopen - /proc/net/tcp6

To prevent this, have added a file check to the smtp_listen.rb