### PR TITLE
Added parameter to whitelist system accounts to allow non-nologin shells

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -42,6 +42,7 @@
 # @param motd Optional string to be content of /etc/motd.  If $banner is defined and $motd is not, $banner becomes content of /etc/motd
 # @param auto_restart If an automatic restart should occur when defined classes require a reboot to take effect
 # @param schedule If you want to change when this runs use a scheduler
+# @param nologin_whitelist Array of accounts to allow login shell other than nologin
 #
 # @example
 #   include secure_linux_cis
@@ -111,6 +112,7 @@ class secure_linux_cis (
   Array                                   $repolist                = ['updates/7/x86_64','rhel-7-server-rpms/7Server/x86_64'],
   Optional[String]                        $banner                  = undef,
   Optional[String]                        $motd                    = undef,
+  Array[String]                           $nologin_whitelist       = [],
 ) {
   schedule { 'harden_schedule':
       period      => $hardening_schedule['period'],

--- a/manifests/rules/ensure_system_accounts_are_non_login.pp
+++ b/manifests/rules/ensure_system_accounts_are_non_login.pp
@@ -26,10 +26,12 @@ class secure_linux_cis::rules::ensure_system_accounts_are_non_login(
     }
     unless $facts['nologin'].empty {
       $facts['nologin'].each | String $user | {
-        exec { "nologin ${user}":
-          command  => "usermod -s ${nologin} ${user}",
-          schedule => 'harden_schedule',
-          path     => '/sbin/:/usr/sbin',
+        if ! ($user in $secure_linux_cis::nologin_whitelist) {
+          exec { "nologin ${user}":
+            command  => "usermod -s ${nologin} ${user}",
+            schedule => 'harden_schedule',
+            path     => '/sbin/:/usr/sbin',
+          }
         }
       }
     }


### PR DESCRIPTION
This change allows system accounts other than root to have a shell that allows logins, e.g. /bin/bash. This is to support system accounts such as those required for system tools (like nagios) that might require shell access