### PR TITLE
Prevent firewalld module from always running regardless of enforced state

### DIFF
--- a/manifests/rules/ensure_firewalld_service_is_enabled_and_running.pp
+++ b/manifests/rules/ensure_firewalld_service_is_enabled_and_running.pp
@@ -9,5 +9,7 @@
 class secure_linux_cis::rules::ensure_firewalld_service_is_enabled_and_running(
     Boolean $enforced = false,
 ) {
-  include ::firewalld
+  if $enforced {
+    include ::firewalld
+  }
 }


### PR DESCRIPTION
Noticed this when I declared the firewalld class elsewhere - this class does not utilise the enforced variable - and so gets executed regardless of it's value.

(Closed old pull request, and opened this one on it's own branch)