### PR TITLE
delete yaml override of auto_restart

### DIFF
--- a/data/common.yaml
+++ b/data/common.yaml
@@ -1,8 +1,6 @@
 ---
 secure_linux_cis::firewall_package: firewall
 # Exclude rules that need to be fixed
-secure_linux_cis::auto_restart: true
-
 secure_linux_cis::host_allow_rules:
   - 'sshd: ALL'
   - "ALL: %{facts.networking.network}/%{facts.networking.netmask}"


### PR DESCRIPTION
#34 missed this yaml override - since the default value has been set to false, it's not a good idea to override that within the module itself.