### PR TITLE
Disable IPv6 correctly on Debian flavors

### DIFF
--- a/manifests/distribution/debian9/cis_3_7.pp
+++ b/manifests/distribution/debian9/cis_3_7.pp
@@ -1,5 +1,5 @@
 # @api private
 #
 class secure_linux_cis::distribution::debian9::cis_3_7 {
-  include secure_linux_cis::rules::ensure_ipv6_is_disabled
+  include secure_linux_cis::rules::disable_ipv6
 }

--- a/manifests/distribution/ubuntu18/cis_3_3_3.pp
+++ b/manifests/distribution/ubuntu18/cis_3_3_3.pp
@@ -1,5 +1,5 @@
 # @api private
 #
 class secure_linux_cis::distribution::ubuntu18::cis_3_3_3 {
-  include secure_linux_cis::rules::ensure_ipv6_is_disabled
+  include secure_linux_cis::rules::disable_ipv6
 }


### PR DESCRIPTION
There is a rules::ensure_ipv6_is_disabled class that assumes a Red Hat
like system and there is a disable_ipv6 that works for most Linux
systems. The CIS benchmark for Debian9 and Debian10 use the title
'Disable IPv6' and the Ubuntu18 document uses the title 'Ensure IPv6 is
disabled'. All 3 give remediation code that is consistent with our
rules::disable_ipv6 code.