### PR TITLE
Correct permissions for /etc/shadow- on Debian*

### DIFF
--- a/manifests/rules/ensure_permissions_on_etc_shadow__are_configured.pp
+++ b/manifests/rules/ensure_permissions_on_etc_shadow__are_configured.pp
@@ -17,8 +17,11 @@ class secure_linux_cis::rules::ensure_permissions_on_etc_shadow__are_configured(
   if $enforced {
     $os = "${facts['os']['name']}${facts['os']['release']['major']}"
     $mode = $os ? {
-      'Debian10' => '0600',
-      default    => '0644',
+      'Debian10'    => '0600',
+      'Debian9'     => '0640',
+      'Ubuntu16.04' => '0640',
+      'Ubuntu18.04' => '0640',
+      default       => '0000',
     }
 
     case $facts['osfamily'] {


### PR DESCRIPTION
Looked at the CIS benchmarks for a few Debian flavored distributions and
noticed that most of them want /etc/shadow- to be 0640 or better.
Debian10 appears to be the exception with 0600 or better.

Also set the default to '0000' as there cannot be a sane reason to have
/etc/shadow- world readable.