### PR TITLE
Add exclude param to CIS 2.2.2 & re enable

### DIFF
--- a/data/os/RedHat/version/7.yaml
+++ b/data/os/RedHat/version/7.yaml
@@ -52,7 +52,7 @@ secure_linux_cis::workstation_level_1:
   - secure_linux_cis::distribution::rhel7::cis_2_2_1_1
   - secure_linux_cis::distribution::rhel7::cis_2_2_1_2
   - secure_linux_cis::distribution::rhel7::cis_2_2_1_3
-  # - secure_linux_cis::distribution::rhel7::cis_2_2_2 # difficult to enforce
+  - secure_linux_cis::distribution::rhel7::cis_2_2_2
   - secure_linux_cis::distribution::rhel7::cis_2_2_3
   - secure_linux_cis::distribution::rhel7::cis_2_2_5
   - secure_linux_cis::distribution::rhel7::cis_2_2_6
@@ -281,7 +281,7 @@ secure_linux_cis::server_level_1:
   - secure_linux_cis::distribution::rhel7::cis_2_2_1_1
   - secure_linux_cis::distribution::rhel7::cis_2_2_1_2
   - secure_linux_cis::distribution::rhel7::cis_2_2_1_3
-  # - secure_linux_cis::distribution::rhel7::cis_2_2_2 # difficult to enforce
+  - secure_linux_cis::distribution::rhel7::cis_2_2_2
   - secure_linux_cis::distribution::rhel7::cis_2_2_3
   - secure_linux_cis::distribution::rhel7::cis_2_2_4
   - secure_linux_cis::distribution::rhel7::cis_2_2_5

--- a/lib/facter/xorg_x11_packages.rb
+++ b/lib/facter/xorg_x11_packages.rb
@@ -6,7 +6,7 @@ Facter.add('xorg_x11_packages') do
   confine osfamily: 'RedHat'
   confine kernel: :linux
   setcode do
-    package_list = Facter::Core::Execution.exec('rpm -qa xorg-x11*')
+    package_list = Facter::Core::Execution.exec('rpm --qf "%{NAME}\n" -qa xorg-x11*')
     package_list.split("\n")
   end
 end
@@ -14,7 +14,7 @@ Facter.add('xorg_x11_packages') do
   confine osfamily: 'Debian'
   confine kernel: :linux
   setcode do
-    package_list = Facter::Core::Execution.exec('dpkg-query -W xserver-xorg*')
+    package_list = Facter::Core::Execution.exec("dpkg-query --showformat='${Package}\n' -W xserver-xorg*")
     package_list.split("\n")
   end
 end

--- a/manifests/rules/ensure_x_window_system_is_not_installed.pp
+++ b/manifests/rules/ensure_x_window_system_is_not_installed.pp
@@ -11,18 +11,36 @@
 #
 # @summary  Ensure X Window System is not installed (Scored)
 #
-# @param enforced Should this rule be enforced
+# @param enforced
+#   Should this rule be enforced - defaults to false - test before enabling as some xorg packages may be required as dependancies. 
+#   See exclude param if you need to exclude packages from removal
+#
+# @param exclude 
+#   Optional Array of xorg packages to NOT remove. This may want to be used if specific xorg packages are required as dependancies. 
+#   Must match exactly with the package name obtained through the xorg_x11_packages fact.
 #
 # @example
 #   include secure_linux_cis::ensure_x_window_system_is_not_installed
+#
+# @example Using hiera
+# secure_linux_cis::rules::ensure_x_window_system_is_not_installed::enforced:: true
+# secure_linux_cis::rules::ensure_x_window_system_is_not_installed::exclude:
+#   - 'xorg-x11-font-utils'
+#   - 'xorg-x11-fonts-Type1'
+
 class secure_linux_cis::rules::ensure_x_window_system_is_not_installed(
-    Boolean $enforced = true,
+    Boolean $enforced = false,
+    Optional[Array] $exclude = undef,
 ) {
   if $enforced {
     unless $facts['xorg_x11_packages'].empty {
-      package { $facts['xorg_x11_packages']:
-        ensure   => purged,
-        schedule => 'harden_schedule',
+      $facts['xorg_x11_packages'].each |String $package| {
+        if ! ($package in $exclude) {
+          package { $package:
+          ensure   => purged,
+          schedule => 'harden_schedule',
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
Debian side may need more testing - I do not currently have any debian dev servers to test this module on.

At least on the redhat front - Some xorg packages are required as dependancies for some packages - openJDK has dependancies on some xorg font packages for example.
Enforcing the removal of all xorg packages means forcing the removal of packages that rely on these. This is unsafe, and I assume why this control was disabled for RHEL7 recently.

I've added an exclude param, so packages to be left alone can be defined in hiera. Because puppet does not allow the use of variables within regex, and I couldn't get partial matches to work without getting really messy - I've opted to strip version & architecture information from the fact, so a full match can be made.

enforced variable default has been changed to false, as this control can be dangerous if not tested sufficiently.