### PR TITLE
Adjust /var/log permission enforcement

### DIFF
--- a/manifests/rules/ensure_permissions_on_all_logfiles_are_configured.pp
+++ b/manifests/rules/ensure_permissions_on_all_logfiles_are_configured.pp
@@ -1,7 +1,13 @@
 # @api private
-# A description of what this class does
+#  Ensure permissions on all logfiles are configured (Scored)
 #
-# @summary A short summary of the purpose of this class
+# Description:
+# Log files stored in /var/log/ contain logged information from many services on the system, or on log hosts others as well.
+#
+# Rationale:
+# It is important to ensure that log files have the correct permissions to ensure that sensitive data is archived and protected.
+#
+# @summary  Ensure permissions on all logfiles are configured (Scored)
 #
 # @param enforced Should this rule be enforced
 #
@@ -11,14 +17,18 @@ class secure_linux_cis::rules::ensure_permissions_on_all_logfiles_are_configured
     Boolean $enforced = true,
 ) {
   if $enforced {
-    # Recursively set permissions on /var/log
-    # Note: Ignoring puppet logs because Puppet manages it's own log permissions
-    file { '/var/log':
-      ensure   => directory,
+    # Recursively set permissions on files & directories within /var/log/ - leaving /var/log itself alone.
+    # Use of file resource is blocked by https://tickets.puppetlabs.com/browse/PUP-1444
+    # Note: puppetlabs directory is excluded because Puppet manages it's own log permissions
+    exec { 'set permissions on /var/log subdirectories':
+      command  => 'find /var/log -mindepth 1 -type d -not \( -path /var/log/puppetlabs -prune \) -exec chmod g-w,o-rwx "{}" \;',
+      path     => ['/usr/bin', '/usr/sbin',],
       schedule => 'harden_schedule',
-      recurse  => true,
-      mode     => 'g-wx,o-rwx',  #lint:ignore:no_symbolic_file_modes
-      ignore   => ['log', 'puppet*'],
+    } ->
+    exec { 'set permissions on /var/log files':
+      command  => 'find /var/log -type f -not \( -path /var/log/puppetlabs/\* -prune \) -exec chmod g-wx,o-rwx "{}" \;',
+      path     => ['/usr/bin', '/usr/sbin',],
+      schedule => 'harden_schedule',
     }
   }
 }


### PR DESCRIPTION
RHEL 8 CIS documentation was referenced for the permission controls set in this pull request. I have not reviewed CIS documentation for other operating systems. Please advise if changes will need to be made.

The current implementation of this control applies the same restrictive permissions to /var/log itself, preventing any user other than root from reading files in a subdirectory, regardless of whether they own the file or not.  This is because recursive file resources cannot exclude the target. I see there was an effort to exclude the log directory itself, so I don't believe this was intended, but rather an accidental oversight.

There is [an open ticket with puppetlabs about this](https://tickets.puppetlabs.com/browse/PUP-1444) 

Because of this bug, I have changed this control to use two find & exec puppet execs instead. Still excluding the puppetlabs directory, but now setting the correct permissions as per RHEL 8 CIS documentation. (Leaving execute permissions on group for subdirectories)