### PR TITLE
Manage /var/log permissions with a fact

### DIFF
--- a/files/var_log_permissions.sh
+++ b/files/var_log_permissions.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+find /var/log -path '/var/log/puppet*' -prune -o -type f -perm /037 -print

--- a/lib/facter/var_log_permissions.rb
+++ b/lib/facter/var_log_permissions.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# var_log_permissions.rb
+# Custom fact that contains all files in /var/log that wrong permissions.
+
+Facter.add('var_log_permissions') do
+  confine kernel: 'Linux'
+  setcode "/usr/share/cis_scripts/var_log_permissions.sh"
+end

--- a/manifests/rules/ensure_permissions_on_all_logfiles_are_configured.pp
+++ b/manifests/rules/ensure_permissions_on_all_logfiles_are_configured.pp
@@ -1,7 +1,15 @@
 # @api private
-# A description of what this class does
+# Ensure permissions on all logfiles are configured (Scored)
+
+# Description:
+# Log files stored in /var/log/ contain logged information from many services on the system,
+# or on log hosts others as well.
 #
-# @summary A short summary of the purpose of this class
+# Rationale:
+# It is important to ensure that log files have the correct permissions to ensure that sensitive
+#data is archived and protected.
+#
+# @summary Ensure permissions on all logfiles are configured (Scored)
 #
 # @param enforced Should this rule be enforced
 #
@@ -11,14 +19,20 @@ class secure_linux_cis::rules::ensure_permissions_on_all_logfiles_are_configured
     Boolean $enforced = true,
 ) {
   if $enforced {
-    # Recursively set permissions on /var/log
-    # Note: Ignoring puppet logs because Puppet manages it's own log permissions
-    file { '/var/log':
-      ensure   => directory,
+    file { '/usr/share/cis_scripts/var_log_permissions.sh':
+      ensure   => file,
       schedule => 'harden_schedule',
-      recurse  => true,
-      mode     => 'g-wx,o-rwx',  #lint:ignore:no_symbolic_file_modes
-      ignore   => ['log', 'puppet*'],
+      owner    => 'root',
+      group    => 'root',
+      mode     => '0700',
+      content  => file('secure_linux_cis/var_log_permissions.sh'),
+    }
+    # Fix permissions on all files reported by this fact as wrong.
+    if $facts['var_log_permissions'] {
+      file { $facts['var_log_permissions']:
+        schedule => 'harden_schedule',
+        mode     => 'g-wx,o-rwx',  #lint:ignore:no_symbolic_file_modes
+      }
     }
   }
 }

--- a/manifests/rules/ensure_permissions_on_all_logfiles_are_configured.pp
+++ b/manifests/rules/ensure_permissions_on_all_logfiles_are_configured.pp
@@ -29,7 +29,8 @@ class secure_linux_cis::rules::ensure_permissions_on_all_logfiles_are_configured
     }
     # Fix permissions on all files reported by this fact as wrong.
     if $facts['var_log_permissions'] {
-      file { $facts['var_log_permissions']:
+      $logfiles = split($facts['var_log_permissions'],'\n')
+      file { $logfiles:
         schedule => 'harden_schedule',
         mode     => 'g-wx,o-rwx',  #lint:ignore:no_symbolic_file_modes
       }


### PR DESCRIPTION
The new fact 'var_log_permissions' lists all files in /var/log that have
write or executable permissions for the group, or any permissions for
others.

The secure_linux_cis::rules::ensure_permissions_on_all_logfiles_are_configured
class uses this fact to fix the permissions of these files.

Files in /var/log/puppet* are skipped, as it is assumed that Puppet
manages these.

Only files (and not for instance directories) are checked by the fact,
as (at least for Debian10, Ubuntu18 and CentOS7) the CIS-CAT Pro
Assessor only checks for permissions on files. The CIS-CAT Pro Assessor
first does a find on /var/log for any file of type 'd' and then, for
each directory found does a find -maxdepth 1 -type f to harvest the
permissions. Fixing only the permissions of files of type 'f' then makes
sense.

TODO maybe make the fact more configurable (skipping directories other
than puppet's)?