### PR TITLE
do_ipv6 not set in  ensure_source_routed_packets_are_not_accepted.pp

### DIFF
--- a/manifests/rules/ensure_source_routed_packets_are_not_accepted.pp
+++ b/manifests/rules/ensure_source_routed_packets_are_not_accepted.pp
@@ -29,7 +29,11 @@ class secure_linux_cis::rules::ensure_source_routed_packets_are_not_accepted(
     if $facts['osfamily'] == 'Debian' or ($facts['osfamily'] == 'RedHat' and $facts['os']['release']['major'] == '8') {
       if $::secure_linux_cis::ipv6_enabled {
         $do_ipv6 = true
+      } else {
+        $do_ipv6 = false
       }
+    } else {
+      $do_ipv6 = false
     }
     sysctl { 'net.ipv4.conf.all.accept_source_route':
       value    => 0,


### PR DESCRIPTION
There are branches of the if statements that fail to set do_ipv6 which is required with the code below the if statement.  

This commit makes sure that it is set for any outcome.