### PR TITLE
Change dependencies on cron and logrotate modules #63

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -54,7 +54,7 @@
     },
     {
       "name": "puppet/cron",
-      "version_requirement": ">= 1.3.0 < 2.0.0"
+      "version_requirement": ">= 1.3.0 < 3.0.0"
     },
     {
       "name": "puppet/firewalld",
@@ -62,7 +62,7 @@
     },
     {
       "name": "puppet/logrotate",
-      "version_requirement": ">= 4.0.0 < 5.0.0"
+      "version_requirement": ">= 4.0.0 < 6.0.0"
     },
     {
       "name": "puppetlabs/augeas_core",


### PR DESCRIPTION
Increase the dependency on puppet/cron and puppet/logrotate to include the next major release of these modules. May fix #63