### PR TITLE
Added exclude_logs to the ensure_permissions_on_all_logfiles_are_configured

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,6 +9,7 @@
 # @param time_servers Array of valid NTP Time servers
 # @param logging How logging is done
 # @param logging_host Which host should logging be sent to
+# @param exclude_logs What logs files to exclude from management
 # @param is_logging_host Is this host a logging host
 # @param max_log_file Maximum log file
 # @param max_auth_tries How many authorization attempts to allow
@@ -83,6 +84,7 @@ class secure_linux_cis (
   Enum['rsyslog', 'syslog-ng', 'none']    $logging                 = 'rsyslog',
   String                                  $logging_host            = '',  #lint:ignore:empty_string_assignment
   Boolean                                 $is_logging_host         = false,
+  Array[Stdlib::Unixpath]                 $exclude_logs            = [],
   Integer                                 $max_log_file            = 32,
   Integer[1,4]                            $max_auth_tries          = 4,
   Integer[1,10]                           $max_sessions            = 4,

--- a/manifests/rules/ensure_permissions_on_all_logfiles_are_configured.pp
+++ b/manifests/rules/ensure_permissions_on_all_logfiles_are_configured.pp
@@ -7,16 +7,18 @@
 #
 # Rationale:
 # It is important to ensure that log files have the correct permissions to ensure that sensitive
-#data is archived and protected.
+# data is archived and protected.
 #
 # @summary Ensure permissions on all logfiles are configured (Scored)
 #
 # @param enforced Should this rule be enforced
+# @param exclude_logs Array of logs to exclude from permissions enforcement
 #
 # @example
 #   include secure_linux_cis::ensure_permissions_on_all_logfiles_are_configured
 class secure_linux_cis::rules::ensure_permissions_on_all_logfiles_are_configured(
     Boolean $enforced = true,
+    Array[Stdlib::Unixpath] $exclude_logs = $secure_linux_cis::exclude_logs,
 ) {
   if $enforced {
     file { '/usr/share/cis_scripts/var_log_permissions.sh':
@@ -31,7 +33,11 @@ class secure_linux_cis::rules::ensure_permissions_on_all_logfiles_are_configured
     # Fix permissions on all files reported by this fact as wrong.
     if $facts['var_log_permissions'] {
       $logfiles = split($facts['var_log_permissions'],'\n')
-      file { $logfiles:
+
+      # Remove any ignored logs from the list.
+      $_logfiles = $logfiles - $exclude_logs
+
+      file { $_logfiles:
         schedule => 'harden_schedule',
         mode     => 'g-wx,o-rwx',  #lint:ignore:no_symbolic_file_modes
       }


### PR DESCRIPTION
rule to ignore certain files (generally ones managed by other modules)