### PR TITLE
Fixed the ensure_journal rules so that they can be set to enforced false

### DIFF
--- a/manifests/rules/ensure_journald_is_configured_to_compress_large_log_files.pp
+++ b/manifests/rules/ensure_journald_is_configured_to_compress_large_log_files.pp
@@ -14,7 +14,7 @@ class secure_linux_cis::rules::ensure_journald_is_configured_to_compress_large_l
       schedule => 'harden_schedule',
       path     => '/etc/systemd/journald.conf',
       line     => 'Compress=yes',
-      match    => '^Compress\ ?=',
+      match    => '^Compress\ *=',
       multiple => true,
     }
   }

--- a/manifests/rules/ensure_journald_is_configured_to_compress_large_log_files.pp
+++ b/manifests/rules/ensure_journald_is_configured_to_compress_large_log_files.pp
@@ -6,12 +6,16 @@
 #
 # @example
 #   include secure_linux_cis::rules::ensure_journald_is_configured_to_compress_large_log_files
-class secure_linux_cis::rules::ensure_journald_is_configured_to_compress_large_log_files {
-  file_line { 'journald_compress':
-    schedule => 'harden_schedule',
-    path     => '/etc/systemd/journald.conf',
-    line     => 'Compress=yes',
-    match    => '^Compress=',
-    multiple => true,
+class secure_linux_cis::rules::ensure_journald_is_configured_to_compress_large_log_files (
+    Boolean $enforced = true,
+) {
+  if $enforced {
+    file_line { 'journald_compress':
+      schedule => 'harden_schedule',
+      path     => '/etc/systemd/journald.conf',
+      line     => 'Compress=yes',
+      match    => '^Compress\ ?=',
+      multiple => true,
+    }
   }
 }

--- a/manifests/rules/ensure_journald_is_configured_to_send_logs_to_rsyslog.pp
+++ b/manifests/rules/ensure_journald_is_configured_to_send_logs_to_rsyslog.pp
@@ -6,12 +6,16 @@
 #
 # @example
 #   include secure_linux_cis::rules::ensure_journald_is_configured_to_send_logs_to_rsyslog
-class secure_linux_cis::rules::ensure_journald_is_configured_to_send_logs_to_rsyslog {
-  file_line { 'journald_syslog':
-    schedule => 'harden_schedule',
-    path     => '/etc/systemd/journald.conf',
-    line     => 'ForwardToSyslog=yes',
-    match    => '^ForwardToSyslog=',
-    multiple => true,
+class secure_linux_cis::rules::ensure_journald_is_configured_to_send_logs_to_rsyslog (
+    Boolean $enforced = true,
+) {
+  if $enforced {
+    file_line { 'journald_syslog':
+      schedule => 'harden_schedule',
+      path     => '/etc/systemd/journald.conf',
+      line     => 'ForwardToSyslog=yes',
+      match    => '^ForwardToSyslog\ ?=',
+      multiple => true,
+    }
   }
 }

--- a/manifests/rules/ensure_journald_is_configured_to_send_logs_to_rsyslog.pp
+++ b/manifests/rules/ensure_journald_is_configured_to_send_logs_to_rsyslog.pp
@@ -14,7 +14,7 @@ class secure_linux_cis::rules::ensure_journald_is_configured_to_send_logs_to_rsy
       schedule => 'harden_schedule',
       path     => '/etc/systemd/journald.conf',
       line     => 'ForwardToSyslog=yes',
-      match    => '^ForwardToSyslog\ ?=',
+      match    => '^ForwardToSyslog\ *=',
       multiple => true,
     }
   }

--- a/manifests/rules/ensure_journald_is_configured_to_write_logfiles_to_persistent_disk.pp
+++ b/manifests/rules/ensure_journald_is_configured_to_write_logfiles_to_persistent_disk.pp
@@ -14,7 +14,7 @@ class secure_linux_cis::rules::ensure_journald_is_configured_to_write_logfiles_t
       schedule => 'harden_schedule',
       path     => '/etc/systemd/journald.conf',
       line     => 'Storage=persistent',
-      match    => '^Storage\ ?=',
+      match    => '^Storage\ *=',
       multiple => true,
     }
   }

--- a/manifests/rules/ensure_journald_is_configured_to_write_logfiles_to_persistent_disk.pp
+++ b/manifests/rules/ensure_journald_is_configured_to_write_logfiles_to_persistent_disk.pp
@@ -6,12 +6,16 @@
 #
 # @example
 #   include secure_linux_cis::rules::ensure_journald_is_configured_to_write_logfiles_to_persistent_disk
-class secure_linux_cis::rules::ensure_journald_is_configured_to_write_logfiles_to_persistent_disk {
-  file_line { 'journald_persist':
-    schedule => 'harden_schedule',
-    path     => '/etc/systemd/journald.conf',
-    line     => 'Storage=persistent',
-    match    => '^Storage=',
-    multiple => true,
+class secure_linux_cis::rules::ensure_journald_is_configured_to_write_logfiles_to_persistent_disk (
+    Boolean $enforced = true,
+) {
+  if $enforced {
+    file_line { 'journald_persist':
+      schedule => 'harden_schedule',
+      path     => '/etc/systemd/journald.conf',
+      line     => 'Storage=persistent',
+      match    => '^Storage\ ?=',
+      multiple => true,
+    }
   }
 }


### PR DESCRIPTION
All other rules have Boolean $enforced in the headers.  These ones dont and I need to disable them on my systems.