### PR TITLE
Fix the nologin fact for puppet7.   

### DIFF
--- a/lib/facter/nologin.rb
+++ b/lib/facter/nologin.rb
@@ -13,7 +13,7 @@ Facter.add('nologin') do
     users = []
 
     user_list.each do |user|
-      users.push(%r{^[^:]*}.match(user))
+      users.push(%r{^[^:]*}.match(user).to_s)
     end
     users
   end


### PR DESCRIPTION
MatchData must be explicitly cast to String with a call to to_s