### PR TITLE
Add Oracle Linux 8 support to CIS 1.5.3 rule.

### DIFF
--- a/manifests/rules/ensure_authentication_required_for_single_user_mode.pp
+++ b/manifests/rules/ensure_authentication_required_for_single_user_mode.pp
@@ -27,7 +27,7 @@ class secure_linux_cis::rules::ensure_authentication_required_for_single_user_mo
           }
         }
       }
-      'RedHat8','CentOS8': {
+      'RedHat8', 'CentOS8', 'OracleLinux8': {
         file_line { 'rescue':
           schedule => 'harden_schedule',
           path     => '/usr/lib/systemd/system/rescue.service',


### PR DESCRIPTION
I noticed there wasn't an option for OL8 in this rule while troubleshooting a node's hardening report. It's an easy enough change to make.

I also added spacing after commas to match the Debian/Ubuntu line.